### PR TITLE
주간 자동 글 초안 — 2026-06-08

### DIFF
--- a/src/content/logs/2026-06-02-prerender-spa-indexing.mdx
+++ b/src/content/logs/2026-06-02-prerender-spa-indexing.mdx
@@ -1,0 +1,29 @@
+---
+title: SPA를 크롤러가 읽게 만들기 — 빌드타임 prerender로 색인 강화
+date: '2026-06-02 21:00'
+type: Building
+summary: React SPA는 크롤러에 빈 div로 보였다. 빌드 타임에 라우트 110개를 정적 HTML로 prerender하고 라우트별 canonical과 title을 주입해 색인을 살렸다.
+---
+
+## 맥락
+
+이 사이트는 React SPA다. 사람 브라우저에는 잘 보이지만, 크롤러가 처음 받는 건 자바스크립트가 채우기 전의 빈 컨테이너다. 본문도, 페이지별 제목도, canonical도 없는 한 장짜리 껍데기 — 검색엔진 입장에선 사실상 내용이 없는 사이트였다.
+
+## 한 일
+
+빌드 단계에서 모든 라우트를 미리 렌더해 정적 HTML로 떨궜다.
+
+- SSR 엔트리로 라우트 110개를 prerender — 크롤러가 JS 실행 없이도 본문을 받는다
+- 라우트별 head 메타 주입 — 페이지마다 고유한 title과 canonical
+- sitemap을 정본 URL(trailing-slash)로 통일하고 빌드 타임에 생성
+- robots 크롤링 허용 + skip-link 등 접근성 보강
+
+## 결정 — 색인은 빌드 산출물로 보장한다
+
+런타임 하이드레이션에 색인을 맡기지 않는다. "크롤러가 JS를 돌려줄 것"이라는 가정은 약하다. 대신 빌드가 끝나면 모든 페이지가 이미 완성된 HTML로 디스크에 존재하도록 만들었다. 색인 가능성을 런타임 운에서 빌드 보증으로 옮긴 것이다.
+
+## 회고
+
+prerender는 화면을 하나도 안 바꿨다 — 사람 눈엔 전과 똑같다. 그래서 미루기 쉬웠지만, 보이지 않는 독자(크롤러)도 사용자다. 빌드 타임에 한 번 더 일해서 런타임의 불확실성을 없애는 패턴은, 색인뿐 아니라 이 사이트의 다른 곳에도 적용할 만하다.
+
+관련: [/essays/site-alive-signals](/essays/site-alive-signals), [/logs#2026-06-07-healthcheck-six-bots](/logs#2026-06-07-healthcheck-six-bots)


### PR DESCRIPTION
## weekly-garden-writer 루틴 테스트 실행

스케줄 루틴(`weekly-garden-writer`, 매주 월요일)이 수행하는 절차를 수동으로 1회 실행한 결과입니다. **머지는 사람이 합니다.**

### 이번 주 소재 요약
- 지난 7일 작업: 헬스체크·silent failure·순수함수 테스트·보안 위생·가든봇 전환 → **직전에 5편으로 이미 게시됨**
- 따라서 "억지로 3편 채우지 않고" 겹치지 않는 새 각도 **1편**만 작성 (휴경 우선 로직 시연)

### 작성한 글 (1편)
- `src/content/logs/2026-06-02-prerender-spa-indexing.mdx` — SPA를 크롤러가 읽게 만들기 (빌드타임 prerender 색인)

### 기밀 추상화 메모
- 개인 레포 + 이 사이트 인프라 회고만 사용. 회사 레포(pointhub-web/adserver) 소재 제외.
- 직무 탐색 신호가 될 수 있는 career/이력서 작업은 의도적으로 제외.

### 검증
- `npm test` 68/68 pass · `npm run build` 성공 (prerender 110 routes) · 신규글 `/logs` HTML 포함 확인

> 이 PR을 머지하면 GitHub Actions가 배포합니다. 닫으면 게시되지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* SEO 및 접근성 개선에 관한 기술 로그 추가
  * 검색 엔진 크롤러의 클라이언트 사이드 렌더링 문제 해결 방안 설명
  * 빌드 타임 정적 렌더링을 통한 크롤러 색인 최적화
  * 메타데이터 및 사이트맵 관리 개선
  * 웹 접근성 강화 기록 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->