### PR TITLE
polish: 최종 점검 반영 — 홈 Essays 프리뷰 + About 심화 + 카피 정합

### DIFF
--- a/src/content/about.json
+++ b/src/content/about.json
@@ -67,6 +67,11 @@
       "title": "dispatch 라우팅 — AI 워크플로우",
       "impact": "3 에이전트 경쟁 + 점수 공식으로 의도 기반 스킬 라우팅을 자동화.",
       "to": "/cases/dispatch-routing-system"
+    },
+    {
+      "title": "양면 시장 의사결정 — 광고 플랫폼",
+      "impact": "광고주와 매체의 인센티브가 충돌하는 지점에서, 기본값과 모니터링을 약한 쪽으로 설계한 판단.",
+      "to": "/essays/two-sided-market-decisions"
     }
   ]
 }

--- a/src/content/site.json
+++ b/src/content/site.json
@@ -17,6 +17,11 @@
     "team-onboarding-doc-system",
     "dispatch-routing-system"
   ],
+  "featuredEssaySlugs": [
+    "why-not-traditional-resume",
+    "two-sided-market-decisions",
+    "ai-workflow-chains"
+  ],
   "heroProof": [
     {
       "label": "What I shipped",
@@ -50,7 +55,7 @@
     {
       "audience": "Future me",
       "question": "오늘의 판단을 어떻게 내일의 자산으로 만들까?",
-      "answer": "빌더 로그와 디지털 가든에 공개 가능한 사례를 축적합니다.",
+      "answer": "빌더 로그에 오늘의 판단을 시간순으로 쌓아 공개 가능한 자산으로 남깁니다.",
       "to": "/logs"
     }
   ]

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -14,6 +14,7 @@ import {
 import {
   siteData,
   getAllCases,
+  getAllEssays,
   getAllNotes,
   getAllLogs,
 } from '../lib/content';
@@ -44,6 +45,9 @@ function HomePage() {
   );
   const recentNotes = (tendedNotes.length >= 4 ? tendedNotes : getAllNotes()).slice(0, 4);
   const recentLogs = getAllLogs().slice(0, 3);
+  const featuredEssays = (siteData.featuredEssaySlugs || [])
+    .map((slug) => getAllEssays().find((e) => e.slug === slug))
+    .filter(Boolean);
 
   return (
     <>
@@ -166,6 +170,27 @@ function HomePage() {
         </ul>
         <Link to={ROUTES.notes} className="see-all-link">
           모든 노트 보기 <ArrowUpRight size={16} aria-hidden="true" />
+        </Link>
+      </section>
+
+      <section className="featured-section">
+        <div className="section-header">
+          <p className="eyebrow">Long-form</p>
+          <h2>길게 풀어낸 판단</h2>
+          <p>제품·플랫폼 결정과 일하는 방식을 서사로 정리한 글.</p>
+        </div>
+        <ul className="case-preview-grid">
+          {featuredEssays.map((essay) => (
+            <li key={essay.slug}>
+              <Link to={ROUTES.essayDetail(essay.slug)} className="case-preview-card">
+                <h3>{essay.title}</h3>
+                <p>{essay.summary}</p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+        <Link to={ROUTES.essays} className="see-all-link">
+          모든 에세이 보기 <ArrowUpRight size={16} aria-hidden="true" />
         </Link>
       </section>
 


### PR DESCRIPTION
## 요약
- 맥락: 재정비 완료 후 3-렌즈(채용 첫인상·IA 일관성·남은 약점) 홀리스틱 점검에서 수렴한 개선.
- 변화: 홈 첫 흐름에서 가장 강한 프로덕트 사고 글(Essays)에 도달 가능해지고, About이 홈과 다른 증거로 심화됨.

## 변경 사항
- **홈 Essays 프리뷰 섹션 추가**(Notes-Logs 사이): featuredEssaySlugs로 3축 대표 에세이(why-not-traditional-resume·two-sided-market-decisions·ai-workflow-chains) 고정. 이전엔 Essays 11편이 홈 흐름에서 완전히 빠져 첫인상 경로로는 도달 불가였음.
- **About highlights 4번째 추가**(양면 시장 의사결정): 홈 featuredCases 3개 반복 → 심화.
- **visitorPaths 'Future me' 카피 정합**: answer가 logs+notes를 지시하던 것을 목적지(/logs)와 일치.

## 검증
- garden-tender 링크/따옴표/스키마 0 / prerender 65 routes / 홈 Essays 섹션 prerender 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 홈 화면에 새로운 “Long-form(길게 풀어낸 판단)” 섹션이 추가되어, 추천 에세이들을 카드 형태로 바로 볼 수 있습니다.
  * 추천 에세이 목록과 “모든 에세이 보기” 링크를 통해 더 많은 글로 쉽게 이동할 수 있습니다.
  * 소개 페이지와 사이트 설정에 새로운 하이라이트 및 추천 에세이 항목이 반영되었습니다.
* **Bug Fixes**
  * 추천 에세이 설정이 없어도 홈 화면이 안정적으로 표시되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->